### PR TITLE
docs: explain Claude prompt levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1050,6 +1050,10 @@ claude "analyze this thoroughly and provide detailed recommendations"
 
 ```
 
+Use the escalating prompts — "think" < "think hard" < "think harder" < "ultrathink" — to give Claude progressively larger thinking budgets.
+
+For more details, see Anthropic's official *[Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)* page.
+
 ### Multi-Directory Workspaces
 ```bash
 # Add multiple directories


### PR DESCRIPTION
- Clarifies how each escalating prompt (“think” → “ultrathink”) increases Claude’s thinking budget
- Adds a reference to Anthropic’s official *Claude Code Best Practices* for deeper guidance