### PR TITLE
chore: deprecate `model` global config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ echo 'set -gx ANTHROPIC_API_KEY "sk-your-key-here"' >> ~/.config/fish/config.fis
 claude config
 
 # Set basic defaults 
-claude config set -g model claude-sonnet-4
 claude config set -g verbose true
 claude config set -g outputFormat text
 


### PR DESCRIPTION
Thank you for the very useful resource.

I noticed that the model config option no longer exists.

```py
❯ claude config set -g model claude-sonnet-4
Error: Cannot set 'model'. Only these keys can be modified: apiKeyHelper, installMethod, 
 autoUpdates, theme, verbose, preferredNotifChannel,
 shiftEnterKeyBindingInstalled, editorMode, hasUsedBackslashReturn,
 supervisorMode, autoCompactEnabled, diffTool, env, tipsHistory, 
parallelTasksCount, todoFeatureEnabled, messageIdleNotifThresholdMs,
 autoConnectIde, autoInstallIdeExtension, checkpointingEnabled
```