### PR TITLE
feat: add ClaudeCode Launchpad CLI to Third-Party Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3707,3 +3707,20 @@ export ANTHROPIC_SMALL_FAST_MODEL=deepseek-chat
 3. ###### Now all you need to do is launch `claude`
 
 Find more information from the [Official Deepseek Docs](https://api-docs.deepseek.com/guides/anthropic_api)
+<h2 id="windows-macos-installer">Windows & macOS Community Installer</h2>
+
+[ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) is a community installer that sets up Node.js, Git, and Claude Code automatically on Windows and macOS in about 2 minutes.
+
+**Features:**
+- Two-line live status bar (model, context %, token count, session/weekly usage)
+- Folder picker and right-click context menu integration (Windows)
+- Optional light-blue terminal theme
+- Claude flags support (e.g. `--continue`) from the launcher
+
+**Install:**
+
+1. [Download the latest release](https://github.com/noambrand/kivun-terminal/releases/latest)
+2. Windows: run `ClaudeCode_Launchpad_CLI_Setup.exe` as Administrator
+3. macOS: right-click `ClaudeCode_Launchpad_CLI_Setup_<version>.pkg` → Open
+
+


### PR DESCRIPTION
## What

Adds a new **Windows & macOS Community Installer** section to the Third-Party Integrations chapter.

## Why

The current Third-Party Integrations section covers alternative LLM backends (DeepSeek). This adds a complementary entry for users who need help getting Claude Code installed in the first place — particularly on Windows where setup is non-trivial.

[ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) automates the full setup (Node.js, Git, Claude Code) in ~2 minutes and adds quality-of-life features:

- **Two-line live status bar** — model, context %, token count, session/weekly usage bars
- **Folder picker** — choose project folder from a GUI, no `cd` needed
- **Right-click context menu** — "Open with ClaudeCode Launchpad CLI" on any folder (Windows)
- **Optional terminal theme** — light-blue Kivun theme or keep your own colors
- **Claude flags from launcher** — pass `--continue` or other flags without opening a terminal manually

MIT licensed, open source, v2.3.0 (April 2026).

**GitHub:** https://github.com/noambrand/kivun-terminal  
**Latest release:** https://github.com/noambrand/kivun-terminal/releases/latest